### PR TITLE
remove redeclaration of bit_shift_mode

### DIFF
--- a/include/nil/blueprint/components/algebra/curves/edwards/plonk/non_native/variable_base_multiplication.hpp
+++ b/include/nil/blueprint/components/algebra/curves/edwards/plonk/non_native/variable_base_multiplication.hpp
@@ -37,12 +37,6 @@ namespace nil {
     namespace blueprint {
         namespace components {
 
-            namespace detail {
-                    enum bit_shift_mode {
-                    LEFT,
-                    RIGHT,
-                };
-            }   // namespace detail
             using detail::bit_shift_mode;
 
             template<typename ArithmetizationType, typename CurveType, typename Ed25519Type,


### PR DESCRIPTION
Declared here https://github.com/NilFoundation/zkllvm-blueprint/blob/remove-bit-shift-mode-duplicate/include/nil/blueprint/components/algebra/fields/plonk/bit_shift_constant.hpp/#L47 , should be removed from variable_base_multiplication