### PR TITLE
Added weak connectedness check variant.

### DIFF
--- a/test/algebra/fields/plonk/non_native/bit_composition.cpp
+++ b/test/algebra/fields/plonk/non_native/bit_composition.cpp
@@ -106,10 +106,12 @@ void test_bit_composition(const std::vector<typename BlueprintFieldType::value_t
     if (!CustomAssignments) {
         if (expected_to_pass) {
             crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
-                component_instance, bits, result_check, instance_input, BitsAmount, CheckInput);
+                component_instance, bits, result_check, instance_input,
+                crypto3::detail::connectedness_check_type::STRONG, BitsAmount, CheckInput);
         } else {
             crypto3::test_component_to_fail<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
-                component_instance, bits, result_check, instance_input, BitsAmount, CheckInput);
+                component_instance, bits, result_check, instance_input,
+                crypto3::detail::connectedness_check_type::STRONG, BitsAmount, CheckInput);
         }
     } else {
         auto custom_assignments = crypto3::generate_patched_assignments<BlueprintFieldType,
@@ -117,7 +119,8 @@ void test_bit_composition(const std::vector<typename BlueprintFieldType::value_t
         crypto3::test_component_to_fail_custom_assignments<
             component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>
                 (component_instance, bits, result_check,
-                 custom_assignments, instance_input, BitsAmount, CheckInput);
+                 custom_assignments, instance_input,
+                 crypto3::detail::connectedness_check_type::STRONG, BitsAmount, CheckInput);
     }
 }
 

--- a/test/algebra/fields/plonk/non_native/bit_decomposition.cpp
+++ b/test/algebra/fields/plonk/non_native/bit_decomposition.cpp
@@ -110,17 +110,20 @@ void test_bit_decomposition(typename BlueprintFieldType::value_type input,
     if (!CustomAssignments) {
         if (expected_to_pass) {
             crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
-                component_instance, public_input, result_check, instance_input, BitsAmount);
+                component_instance, public_input, result_check, instance_input,
+                crypto3::detail::connectedness_check_type::STRONG, BitsAmount);
         } else {
             crypto3::test_component_to_fail<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
-                component_instance, public_input, result_check, instance_input, BitsAmount);
+                component_instance, public_input, result_check, instance_input,
+                crypto3::detail::connectedness_check_type::STRONG, BitsAmount);
         }
     } else {
         auto custom_assignments = crypto3::generate_patched_assignments<BlueprintFieldType,
             ArithmetizationParams, component_type>(patches);
         crypto3::test_component_to_fail_custom_assignments<
             component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>
-                (component_instance, public_input, result_check, custom_assignments, instance_input, BitsAmount);
+                (component_instance, public_input, result_check, custom_assignments, instance_input,
+                 crypto3::detail::connectedness_check_type::STRONG, BitsAmount);
     }
 }
 

--- a/test/algebra/fields/plonk/non_native/bit_shift_constant.cpp
+++ b/test/algebra/fields/plonk/non_native/bit_shift_constant.cpp
@@ -90,10 +90,12 @@ void test_bit_shift(typename BlueprintFieldType::value_type input,
 
     if (expected_to_pass) {
         crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
-            component_instance, public_input, result_check, instance_input, BitsAmount, Shift, Mode);
+            component_instance, public_input, result_check, instance_input,
+            nil::crypto3::detail::connectedness_check_type::STRONG, BitsAmount, Shift, Mode);
     } else {
         crypto3::test_component_to_fail<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
-            component_instance, public_input, result_check, instance_input, BitsAmount, Shift, Mode);
+            component_instance, public_input, result_check, instance_input,
+            nil::crypto3::detail::connectedness_check_type::STRONG, BitsAmount, Shift, Mode);
     }
 }
 

--- a/test/algebra/fields/plonk/non_native/comparison_checked.cpp
+++ b/test/algebra/fields/plonk/non_native/comparison_checked.cpp
@@ -106,12 +106,13 @@ auto test_comparison_checked(typename BlueprintFieldType::value_type x,
     if (!CustomAssignments) {
         if (expected_to_pass) {
             nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
-                component_instance, public_input, result_check, instance_input, R, Mode);
+                component_instance, public_input, result_check, instance_input,
+                nil::crypto3::detail::connectedness_check_type::STRONG, R, Mode);
         } else {
             nil::crypto3::test_component_to_fail<component_type, BlueprintFieldType, ArithmetizationParams,
                                                  hash_type, Lambda>(
                                                     component_instance, public_input, result_check, instance_input,
-                                                    R, Mode);
+                                                    nil::crypto3::detail::connectedness_check_type::STRONG, R, Mode);
         }
     } else {
         auto custom_assignment = nil::crypto3::generate_patched_assignments<
@@ -121,12 +122,14 @@ auto test_comparison_checked(typename BlueprintFieldType::value_type x,
             nil::crypto3::test_component_custom_assignments<component_type, BlueprintFieldType, ArithmetizationParams,
                     hash_type, Lambda>(
                         component_instance, public_input,
-                        result_check, custom_assignment, instance_input, R, Mode);
+                        result_check, custom_assignment, instance_input,
+                        nil::crypto3::detail::connectedness_check_type::STRONG, R, Mode);
         } else {
             nil::crypto3::test_component_to_fail_custom_assignments<component_type, BlueprintFieldType,
                     ArithmetizationParams, hash_type, Lambda>(
                             component_instance, public_input, result_check,
-                            custom_assignment, instance_input, R, Mode);
+                            custom_assignment, instance_input,
+                            nil::crypto3::detail::connectedness_check_type::STRONG, R, Mode);
         }
     }
 }

--- a/test/algebra/fields/plonk/non_native/comparison_flag.cpp
+++ b/test/algebra/fields/plonk/non_native/comparison_flag.cpp
@@ -114,12 +114,13 @@ auto test_comparison_flag(typename BlueprintFieldType::value_type x, typename Bl
     if (!CustomAssignments) {
         if (expected_to_pass) {
             nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
-                component_instance, public_input, result_check, instance_input, R, Mode);
+                component_instance, public_input, result_check, instance_input,
+                nil::crypto3::detail::connectedness_check_type::STRONG, R, Mode);
         } else {
             nil::crypto3::test_component_to_fail<component_type, BlueprintFieldType, ArithmetizationParams,
                                                  hash_type, Lambda>(
                                                     component_instance, public_input, result_check, instance_input,
-                                                    R, Mode);
+                                                    nil::crypto3::detail::connectedness_check_type::STRONG, R, Mode);
         }
     } else {
         // Currently, the only custom assignment test here is for failure
@@ -129,7 +130,8 @@ auto test_comparison_flag(typename BlueprintFieldType::value_type x, typename Bl
         nil::crypto3::test_component_to_fail_custom_assignments<component_type, BlueprintFieldType,
                 ArithmetizationParams, hash_type, Lambda>(
                         component_instance, public_input, result_check,
-                        custom_assignment, instance_input, R, Mode);
+                        custom_assignment, instance_input,
+                        nil::crypto3::detail::connectedness_check_type::STRONG, R, Mode);
     }
 }
 

--- a/test/algebra/fields/plonk/non_native/comparison_unchecked.cpp
+++ b/test/algebra/fields/plonk/non_native/comparison_unchecked.cpp
@@ -108,12 +108,13 @@ auto test_comparison_unchecked(typename BlueprintFieldType::value_type x,
     if (!CustomAssignments) {
         if (expected_to_pass) {
             nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
-                component_instance, public_input, result_check, instance_input, R, Mode);
+                component_instance, public_input, result_check, instance_input,
+                nil::crypto3::detail::connectedness_check_type::STRONG, R, Mode);
         } else {
             nil::crypto3::test_component_to_fail<component_type, BlueprintFieldType, ArithmetizationParams,
                                                  hash_type, Lambda>(
                                                     component_instance, public_input, result_check, instance_input,
-                                                    R, Mode);
+                                                    nil::crypto3::detail::connectedness_check_type::STRONG, R, Mode);
         }
     } else {
         auto custom_assignment = nil::crypto3::generate_patched_assignments<
@@ -123,12 +124,14 @@ auto test_comparison_unchecked(typename BlueprintFieldType::value_type x,
             nil::crypto3::test_component_custom_assignments<component_type, BlueprintFieldType, ArithmetizationParams,
                     hash_type, Lambda>(
                         component_instance, public_input,
-                        result_check, custom_assignment, instance_input, R, Mode);
+                        result_check, custom_assignment, instance_input,
+                        nil::crypto3::detail::connectedness_check_type::STRONG, R, Mode);
         } else {
             nil::crypto3::test_component_to_fail_custom_assignments<component_type, BlueprintFieldType,
                     ArithmetizationParams, hash_type, Lambda>(
                             component_instance, public_input, result_check,
-                            custom_assignment, instance_input, R, Mode);
+                            custom_assignment, instance_input,
+                            nil::crypto3::detail::connectedness_check_type::STRONG, R, Mode);
         }
     }
 }

--- a/test/algebra/fields/plonk/non_native/division_remainder.cpp
+++ b/test/algebra/fields/plonk/non_native/division_remainder.cpp
@@ -100,11 +100,13 @@ auto test_division_remainder(typename BlueprintFieldType::value_type x,
     if (!CustomAssignments) {
         if (expected_to_pass) {
             nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
-                component_instance, public_input, result_check, instance_input, R, CheckInputs);
+                component_instance, public_input, result_check, instance_input,
+                nil::crypto3::detail::connectedness_check_type::STRONG, R, CheckInputs);
         } else {
             nil::crypto3::test_component_to_fail<component_type, BlueprintFieldType, ArithmetizationParams,
                                                  hash_type, Lambda>(
                                                     component_instance, public_input, result_check, instance_input,
+                                                    nil::crypto3::detail::connectedness_check_type::STRONG,
                                                     R, CheckInputs);
         }
     } else {
@@ -114,7 +116,8 @@ auto test_division_remainder(typename BlueprintFieldType::value_type x,
         nil::crypto3::test_component_to_fail_custom_assignments<component_type, BlueprintFieldType,
                 ArithmetizationParams, hash_type, Lambda>(
                         component_instance, public_input, result_check,
-                        custom_assignment, instance_input, R, CheckInputs);
+                        custom_assignment, instance_input,
+                        nil::crypto3::detail::connectedness_check_type::STRONG, R, CheckInputs);
     }
 }
 

--- a/test/algebra/fields/plonk/non_native/equality_flag.cpp
+++ b/test/algebra/fields/plonk/non_native/equality_flag.cpp
@@ -83,7 +83,8 @@ void test_equality_flag(const std::vector<typename BlueprintFieldType::value_typ
     component_type component_instance({0, 1, 2, 3, 4}, {}, {}, inequality);
 
     nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>
-        (component_instance, public_input, result_check, instance_input, inequality);
+        (component_instance, public_input, result_check, instance_input,
+         nil::crypto3::detail::connectedness_check_type::STRONG, inequality);
 }
 
 template <typename BlueprintFieldType, std::size_t RandomTestsAmount>

--- a/test/algebra/fields/plonk/range_check.cpp
+++ b/test/algebra/fields/plonk/range_check.cpp
@@ -104,11 +104,13 @@ auto test_range_check(typename BlueprintFieldType::value_type input,
     if (!CustomAssignments) {
         if (expected_to_pass) {
             nil::crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
-                component_instance, public_input, result_check, instance_input, R);
+                component_instance, public_input, result_check, instance_input,
+                nil::crypto3::detail::connectedness_check_type::STRONG, R);
         } else {
             nil::crypto3::test_component_to_fail<component_type, BlueprintFieldType, ArithmetizationParams,
                                                  hash_type, Lambda>(
-                                                    component_instance, public_input, result_check, instance_input, R);
+                                                    component_instance, public_input, result_check, instance_input,
+                                                    nil::crypto3::detail::connectedness_check_type::STRONG, R);
         }
     } else {
         auto custom_assignment = nil::crypto3::generate_patched_assignments<
@@ -118,12 +120,14 @@ auto test_range_check(typename BlueprintFieldType::value_type input,
             nil::crypto3::test_component_custom_assignments<component_type, BlueprintFieldType, ArithmetizationParams,
                     hash_type, Lambda>(
                         component_instance, public_input,
-                        result_check, custom_assignment, instance_input, R);
+                        result_check, custom_assignment, instance_input,
+                        nil::crypto3::detail::connectedness_check_type::STRONG, R);
         } else {
             nil::crypto3::test_component_to_fail_custom_assignments<component_type, BlueprintFieldType,
                     ArithmetizationParams, hash_type, Lambda>(
                             component_instance, public_input, result_check,
-                            custom_assignment, instance_input, R);
+                            custom_assignment, instance_input,
+                            nil::crypto3::detail::connectedness_check_type::STRONG, R);
         }
     }
 }

--- a/test/non_native/plonk/add_mul_zkllvm_compatible.cpp
+++ b/test/non_native/plonk/add_mul_zkllvm_compatible.cpp
@@ -131,10 +131,12 @@ void test_mul(typename CurveType::base_field_type::value_type b_val,
         // 253 is the default bits_amount
         crypto3::test_component<stretched_component_type, BlueprintFieldType,
                                 ArithmetizationParams, hash_type, Lambda>(
-            stretched_instance, public_input, result_check, instance_input, 253);
+            stretched_instance, public_input, result_check, instance_input,
+            nil::crypto3::detail::connectedness_check_type::STRONG, 253);
     } else {
         crypto3::test_component<component_type, BlueprintFieldType, ArithmetizationParams, hash_type, Lambda>(
-            component_instance, public_input, result_check, instance_input, 253);
+            component_instance, public_input, result_check, instance_input,
+            nil::crypto3::detail::connectedness_check_type::STRONG, 253);
     }
 }
 

--- a/test/test_plonk_component.hpp
+++ b/test/test_plonk_component.hpp
@@ -67,6 +67,14 @@
 
 namespace nil {
     namespace crypto3 {
+        namespace detail {
+            enum class connectedness_check_type {
+                NONE,
+                WEAK,
+                STRONG
+            };
+        }   // namespace detail
+
         inline std::vector<std::size_t> generate_random_step_list(const std::size_t r, const int max_step) {
             using dist_type = std::uniform_int_distribution<int>;
             static std::random_device random_engine;
@@ -174,6 +182,7 @@ namespace nil {
                                                          ArithmetizationParams> &assigner,
                                typename ComponentType::input_type instance_input,
                                bool expected_to_pass,
+                               detail::connectedness_check_type connectedness_check,
                                ComponentStaticInfoArgs... component_static_info_args) {
 
             using ArithmetizationType = zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
@@ -204,24 +213,32 @@ namespace nil {
             result_check(assignment, component_result);
 
             if constexpr (!PrivateInput) {
-                bool is_connected = check_connectedness(
-                    assignment,
-                    bp,
-                    instance_input.all_vars(),
-                    component_result.all_vars(), start_row, component_instance.rows_amount);
+                bool is_connected;
+                if (connectedness_check == detail::connectedness_check_type::STRONG) {
+                    is_connected = check_strong_connectedness(
+                        assignment,
+                        bp,
+                        instance_input.all_vars(),
+                        component_result.all_vars(), start_row, component_instance.rows_amount);
+                } else if (connectedness_check == detail::connectedness_check_type::WEAK) {
+                    is_connected = check_weak_connectedness(
+                        assignment,
+                        bp,
+                        instance_input.all_vars(),
+                        component_result.all_vars(), start_row, component_instance.rows_amount);
+                } else if (connectedness_check == detail::connectedness_check_type::NONE) {
+                    is_connected = true;
+                    std::cout << "WARNING: connectedness check disabled" << std::endl;
+                }
 
                 // Uncomment the following if you want to output a visual representation of the connectedness graph.
                 // I recommend turning off the starting row randomization
 
                 // auto zones = blueprint::detail::generate_connectedness_zones(
-                //     assignment, bp, instance_input.all_vars(), start_row, component_instance.rows_amount);
+                //      assignment, bp, instance_input.all_vars(), start_row, component_instance.rows_amount);
                 // blueprint::detail::export_connectedness_zones(
-                //     zones, assignment, instance_input.all_vars(), start_row, component_instance.rows_amount, std::cout);
+                //      zones, assignment, instance_input.all_vars(), start_row, component_instance.rows_amount, std::cout);
 
-                // It might also happen that your component doesn't actually need to be fully connected.
-                // I anticipate this to happen rarely -- didn't come up for any components yet.
-                // In case it actually does you should write an alternative check for partial connectedness,
-                // and enable in for your component only.
                 BOOST_ASSERT_MSG(is_connected,
                     "Component disconnected! See comment above this assert for a way to output a visual representation of the connectedness graph.");
             }
@@ -276,13 +293,14 @@ namespace nil {
                                 &assigner,
                             const typename ComponentType::input_type &instance_input,
                             bool expected_to_pass,
+                            detail::connectedness_check_type connectedness_check,
                             ComponentStaticInfoArgs... component_static_info_args) {
             auto [desc, bp, assignments] =
                 prepare_component<ComponentType, BlueprintFieldType, ArithmetizationParams, Hash, Lambda,
                                   PublicInputContainerType, FunctorResultCheck, PrivateInput,
                                   ComponentStaticInfoArgs...>
                                   (component_instance, public_input, result_check, assigner, instance_input,
-                                   expected_to_pass, component_static_info_args...);
+                                   expected_to_pass, connectedness_check, component_static_info_args...);
 
 #ifdef BLUEPRINT_PLACEHOLDER_PROOF_GEN_ENABLED
             using placeholder_params =
@@ -330,6 +348,8 @@ namespace nil {
             test_component(ComponentType component_instance, const PublicInputContainerType &public_input,
                            FunctorResultCheck result_check,
                            typename ComponentType::input_type instance_input,
+                           detail::connectedness_check_type connectedness_check =
+                            detail::connectedness_check_type::STRONG,
                            ComponentStaticInfoArgs... component_static_info_args) {
             return test_component_inner<ComponentType, BlueprintFieldType, ArithmetizationParams, Hash, Lambda,
                                  PublicInputContainerType, FunctorResultCheck, false,
@@ -337,7 +357,7 @@ namespace nil {
                                     component_instance, public_input, result_check,
                                     plonk_test_default_assigner<ComponentType, BlueprintFieldType,
                                                                 ArithmetizationParams>(),
-                                    instance_input, true, component_static_info_args...);
+                                    instance_input, true, connectedness_check, component_static_info_args...);
         }
 
         template<typename ComponentType, typename BlueprintFieldType, typename ArithmetizationParams, typename Hash,
@@ -348,13 +368,15 @@ namespace nil {
             test_component_to_fail(ComponentType component_instance, const PublicInputContainerType &public_input,
                            FunctorResultCheck result_check,
                            typename ComponentType::input_type instance_input,
+                           detail::connectedness_check_type connectedness_check =
+                            detail::connectedness_check_type::STRONG,
                            ComponentStaticInfoArgs... component_static_info_args) {
             return test_component_inner<ComponentType, BlueprintFieldType, ArithmetizationParams, Hash, Lambda,
                                  PublicInputContainerType, FunctorResultCheck, false, ComponentStaticInfoArgs...>(
                                     component_instance, public_input, result_check,
                                     plonk_test_default_assigner<ComponentType, BlueprintFieldType,
                                                                 ArithmetizationParams>(),
-                                    instance_input, false, component_static_info_args...);
+                                    instance_input, false, connectedness_check, component_static_info_args...);
         }
 
         template<typename ComponentType, typename BlueprintFieldType, typename ArithmetizationParams, typename Hash,
@@ -368,12 +390,14 @@ namespace nil {
                             const plonk_test_custom_assigner<ComponentType, BlueprintFieldType,
                                                              ArithmetizationParams> &custom_assigner,
                             typename ComponentType::input_type instance_input,
+                            detail::connectedness_check_type connectedness_check =
+                                detail::connectedness_check_type::STRONG,
                             ComponentStaticInfoArgs... component_static_info_args) {
 
                 return test_component_inner<ComponentType, BlueprintFieldType, ArithmetizationParams, Hash, Lambda,
                                  PublicInputContainerType, FunctorResultCheck, false, ComponentStaticInfoArgs...>
                                     (component_instance, public_input, result_check, custom_assigner,
-                                     instance_input, true, component_static_info_args...);
+                                     instance_input, true, connectedness_check, component_static_info_args...);
             }
 
         template<typename ComponentType, typename BlueprintFieldType, typename ArithmetizationParams, typename Hash,
@@ -387,12 +411,14 @@ namespace nil {
                             const plonk_test_custom_assigner<ComponentType, BlueprintFieldType,
                                                              ArithmetizationParams> &custom_assigner,
                             typename ComponentType::input_type instance_input,
+                            detail::connectedness_check_type connectedness_check =
+                                detail::connectedness_check_type::STRONG,
                             ComponentStaticInfoArgs... component_static_info_args) {
 
                 return test_component_inner<ComponentType, BlueprintFieldType, ArithmetizationParams, Hash, Lambda,
                                  PublicInputContainerType, FunctorResultCheck, false, ComponentStaticInfoArgs...>
                                     (component_instance, public_input, result_check, custom_assigner,
-                                     instance_input, false, component_static_info_args...);
+                                     instance_input, false,  connectedness_check,component_static_info_args...);
             }
 
         template<typename ComponentType, typename BlueprintFieldType, typename ArithmetizationParams, typename Hash,
@@ -404,6 +430,8 @@ namespace nil {
             test_component_private_input(ComponentType component_instance,
                             const PublicInputContainerType &public_input, FunctorResultCheck result_check,
                             typename ComponentType::input_type instance_input,
+                            detail::connectedness_check_type connectedness_check =
+                                detail::connectedness_check_type::STRONG,
                             ComponentStaticInfoArgs... component_static_info_args) {
 
                 return test_component_inner<ComponentType, BlueprintFieldType, ArithmetizationParams, Hash, Lambda,
@@ -411,7 +439,7 @@ namespace nil {
                                     (component_instance, public_input, result_check,
                                     plonk_test_default_assigner<ComponentType, BlueprintFieldType,
                                                                 ArithmetizationParams>(),
-                                    instance_input, true, component_static_info_args...);
+                                    instance_input, true, connectedness_check, component_static_info_args...);
             }
 
         template<typename ComponentType, typename BlueprintFieldType, typename ArithmetizationParams, typename Hash,
@@ -423,6 +451,8 @@ namespace nil {
             test_component_to_fail_private_input(ComponentType component_instance,
                             const PublicInputContainerType &public_input, FunctorResultCheck result_check,
                             typename ComponentType::input_type instance_input,
+                            detail::connectedness_check_type connectedness_check =
+                                detail::connectedness_check_type::STRONG,
                             ComponentStaticInfoArgs... component_static_info_args) {
 
                 return test_component_inner<ComponentType, BlueprintFieldType, ArithmetizationParams, Hash, Lambda,
@@ -430,7 +460,7 @@ namespace nil {
                                     (component_instance, public_input, result_check,
                                     plonk_test_default_assigner<ComponentType, BlueprintFieldType,
                                                                 ArithmetizationParams>(),
-                                    instance_input, false, component_static_info_args...);
+                                    instance_input, false, connectedness_check, component_static_info_args...);
             }
 
         /*


### PR DESCRIPTION
Currently, the only connectedness check performed on the components during test is the `STRONG` one: it requires that all inputs are in the same connectedness component as all outputs.
This turned out to be too strong of an assumption for some components. So now there is a `WEAK` variant, where each input is required to be connected to at least one output and vice versa.
There is also a `NONE` variant, which allows disabling the check for either debugging, or unused parameters in the component -- unsure how to handle those appearing for now, did not expect that to ever occur.