### PR TITLE
Add workaround config file to import blueprint package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,3 +163,23 @@ endif()
 if(BUILD_EXAMPLES)
     add_subdirectory(example)
 endif()
+
+# Workaround config file with crypto3::all as a dependency
+# TODO: remove after resolving dependency issues in crypto3
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+# We cannot use "blueprint" name for workaround package since the original one still exists
+set(package_name "blueprint_crypto3")
+set(config_dir ${CMAKE_INSTALL_LIBDIR}/cmake/${package_name})
+
+configure_package_config_file(
+    cmake/Config.cmake.in
+    ${package_name}-config.cmake
+    INSTALL_DESTINATION ${config_dir}
+)
+
+install(
+    FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${package_name}-config.cmake
+    DESTINATION ${config_dir}
+)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,17 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Boost COMPONENTS REQUIRED
+                    container json filesystem log log_setup program_options thread system unit_test_framework)
+find_dependency(crypto3 REQUIRED)
+
+# Protect against multiple inclusion
+if (TARGET blueprint)
+  return()
+endif()
+
+add_library(blueprint INTERFACE IMPORTED)
+
+set_target_properties(blueprint PROPERTIES
+                        INTERFACE_INCLUDE_DIRECTORIES "@CMAKE_INSTALL_FULL_INCLUDEDIR@"
+                        INTERFACE_LINK_LIBRARIES "crypto3::all;${Boost_LIBRARIES}")


### PR DESCRIPTION
Added workaround because of the dependency [issue](https://github.com/NilFoundation/crypto3/issues/175) in crypto3. 
Usage from other project:
```cmake
find_package(blueprint_crypto3 REQUIRED)
...
target_link_libraries(${PROJECT_NAME} blueprint)
```

Note: CI has not passed because of https://github.com/NilFoundation/zkllvm-blueprint/issues/377